### PR TITLE
feat: add commit lint and semantic release pipeline

### DIFF
--- a/.github/workflows/lint-and-release.yaml
+++ b/.github/workflows/lint-and-release.yaml
@@ -1,0 +1,19 @@
+name: Trigger Release
+
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  call-commit-lint-workflow:
+    uses: vre-charite-dev/quickstart/.github/workflows/commit-lint.yaml@main
+
+  call-release-workflow:
+    needs: call-commit-lint-workflow
+    uses: vre-charite-dev/quickstart/.github/workflows/release.yaml@main
+    permissions:
+      contents: write  # Required to create tags, commit changes, etc.
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,36 @@
+{
+  "branches": ["main"],
+  "repositoryUrl": "https://github.com/vre-charite-dev/library_common",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failComment": false,
+        "releasedLabels": false,
+        "assets": ["CHANGELOG.md", "requirements.txt", "setup.py"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+        "labels": [
+          "released",
+          "semantic-release",
+          "release-${nextRelease.version}"
+        ]
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
* adds a pipeline that calls the semantic release pipeline in the quickstart repo that generates a new changelog entry when a new release is being pushed to the main branch 
* adds a pipeline that call a commit lint pipeline in the quickstart repo that checks upon PR creation if all commits in the PR adhere to the conventional commit format