### PR TITLE
chore: do not pin requests library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -95,4 +95,4 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8"
-content-hash = "b625b7162f003deb4b9a66f5c55e68b9d5d1a79c21edadffc88fe3e75115f99d"
+content-hash = "e65d07976a738cd242b67ea27b8f5ab75687d545301d63a9f79b305f36358399"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "common"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-requests = "2.26.0"
+requests = "^2.26.0"
 python-json-logger = "0.1.11"
 
 [build-system]


### PR DESCRIPTION
we want to allow higher versions such as v2.27.0.
we do have use-cases such as using openfeature library which relies on version v2.27.0 and therefore we need to allow this. Dependency management should handle the usage of the most recent, but still compatible version of requests throughout the project.